### PR TITLE
Update to Crystal 0.20.4

### DIFF
--- a/spec/zip/proc-source_spec.cr
+++ b/spec/zip/proc-source_spec.cr
@@ -7,7 +7,7 @@ class TestProcSource < Zip::ProcSource
   def initialize(zip, data)
     # reset position and cache data slice
     @pos = 0
-    @data = data.to_slice as Slice(UInt8)
+    @data = data.to_slice.as Slice(UInt8)
 
     super(zip, ->(
       action    : Zip::Action,
@@ -15,7 +15,7 @@ class TestProcSource < Zip::ProcSource
       user_data : Void* \
     ) {
       # cast data pointer back to "self"
-      me = user_data as TestProcSource
+      me = user_data.as TestProcSource
 
       # switch on action, then coerce result to i64
       0_i64 + case action
@@ -54,7 +54,7 @@ class TestProcSource < Zip::ProcSource
         )
 
         # copy populated struct to slice
-        slice.copy_from(pointerof(st) as Pointer(UInt8), st_size)
+        slice.copy_from(pointerof(st).as(Pointer(UInt8)), st_size)
 
         # return sizeof stat
         st_size
@@ -62,7 +62,7 @@ class TestProcSource < Zip::ProcSource
         # for all other actions, do nothing
         0
       end
-    }, self as Pointer(Void))
+    }, self.as(Pointer(Void)))
   end
 end
 

--- a/src/zip/archive.cr
+++ b/src/zip/archive.cr
@@ -37,7 +37,7 @@ module Zip
   #
   class Archive
     include Enumerable(String)
-    include Iterable
+    include Iterable(String)
 
     protected getter zip
 
@@ -932,7 +932,7 @@ module Zip
       flags     : Int32 = 0_i32,
       password  : String? = nil
     ) : Slice(UInt8)
-      io = MemoryIO.new(stat(path).size)
+      io = IO::Memory.new(stat(path).size)
 
       open(path, flags) do |file|
         # create read buffer

--- a/src/zip/sources.cr
+++ b/src/zip/sources.cr
@@ -256,7 +256,7 @@ module Zip
   #           slice     : Slice(UInt8),
   #           user_data : Void*) {
   #           # cast data pointer back to "self"
-  #           me = user_data as TestProcSource
+  #           me = user_data.as TestProcSource
   #
   #           # switch on action, then coerce result to i64
   #           0_i64 + case action
@@ -295,7 +295,7 @@ module Zip
   #             )
   #
   #             # copy populated struct to slice
-  #             slice.copy_from(pointerof(st) as Pointer(UInt8), st_size)
+  #             slice.copy_from(pointerof(st).as(Pointer(UInt8)), st_size)
   #
   #             # return sizeof stat
   #             st_size
@@ -303,7 +303,7 @@ module Zip
   #             # for all other actions, do nothing
   #             0
   #           end
-  #         }, self as Pointer(Void))
+  #         }, self.as(Pointer(Void)))
   #       end
   #     end
   #
@@ -323,7 +323,7 @@ module Zip
       @proc       : Action, Slice(UInt8), Void* -> Int64,
       @user_data  : Void*
     )
-      super(zip, LibZip.zip_source_function(zip.zip, wrap_proc, self as Void*))
+      super(zip, LibZip.zip_source_function(zip.zip, wrap_proc, self.as(Void*)))
     end
 
     private def wrap_proc
@@ -333,7 +333,7 @@ module Zip
         len           : UInt64,
         action_value  : Int32) do
         # get source, action, and slice
-        source = user_data as ProcSource
+        source = user_data.as ProcSource
         action = Action.new(action_value)
         slice = Slice(UInt8).new(data, len)
 


### PR DESCRIPTION
This PR makes shard usable again under Crystal version `0.20.4`.
I'm not sure though if remaining 2 failing tests might be related to that.